### PR TITLE
build on macOS

### DIFF
--- a/CImg.h
+++ b/CImg.h
@@ -27097,10 +27097,10 @@ namespace cimg_library {
        \param pattern An integer whose bits describe the line pattern (optional).
        \param init_hatch if \c true, reinit hatch motif.
     **/
-    template<typename t>
+    template<typename tn>
     CImg<T>& draw_spline(const int x0, const int y0, const float u0, const float v0,
                          const int x1, const int y1, const float u1, const float v1,
-                         const CImg<t>& texture,
+                         const CImg<tn>& texture,
                          const int tx0, const int ty0, const int tx1, const int ty1,
                          const float opacity=1,
                          const float precision=4, const unsigned int pattern=~0U,


### PR DESCRIPTION
Resolve build error:

```
In file included from main.cpp:1:
./CImg.h:27124:18: error: declaration of 't' shadows template parameter
      for (float t = 0; t<1; t+=_precision) {
                 ^
./CImg.h:27100:23: note: template parameter is declared here
    template<typename t>
                      ^
1 error generated.
```

<img width="953" alt="screen shot 2016-06-19 at 11 05 32 am" src="https://cloud.githubusercontent.com/assets/4391003/16179024/45ad07c0-360e-11e6-8543-77a65516ecd1.png">
